### PR TITLE
Feature: Subdirectory Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,14 @@ Censitive censors all your sensitive information, such as database logins, token
 > .env:.*_KEY,.*_token,.*_PassWord
 > id_rsa:*
 > ```
-2. Reload the window using `Developer: Reload Window`
 3. Open a file of the type specified in `.censitive` and check the censoring
 
 ## Features
 
-The extension uses decorations to block out sensitive information as set in a `.censitive` file in the workspace or in your home directory.
+The extension uses decorations to block out sensitive information as set in a `.censitive` file in a parent directory or in your home directory.
 If both files are present and `censtitive.mergeGlobalCensoring` is enabled, their censoring will be merged.
 
-When active, the extension will censor all content set in `.censitive` file by using a key-value approach.
+When active, the extension will censor all content set in `.censitive` file(s) by using a key-value approach.
 This means, the `.censitive` file specifies key regexes and the extension automatically finds values assigned to these keys.
 However, because the censoring is based solely on regex, some value formats may not be recognized.
 
@@ -51,7 +50,7 @@ This extension has the following settings:
 * `censitive.defaultCensoring`: Default censoring config, if no `.censitive` file is present in the workspace or the user's home directory
 * `censitive.mergeDefaultCensoring`: merge default configuration with all .censitive configurations
 
-The values being censored can be controlled using a `.censitive` file in the workspace root.
+The values being censored can be controlled using a `.censitive` file in the workspace root, or in any other directory.
 The keys are matched case insensitive. Its basic format is:
 
 ```censitive
@@ -66,7 +65,7 @@ The keys are matched case insensitive. Its basic format is:
 <globPattern>!<excludePatterns>:[beginRegex],[keyRegex]:[endRegex]
 ```
 
-The glob pattern is always taken relative to the active workspace(s).
+The glob pattern is always taken relative to the directory the .censitive file is located in.
 If there is no active workspace, all patterns are automatically prepended with `**/`.
 
 Multiple key regular expressions can be provided, by separating them with a comma `,`.
@@ -103,5 +102,6 @@ To completely hide the content of specific files, the shorthand `*` can be used 
 ## Known Issues
 
 * For large documents, it will take some time for the values to get censored. This is unavoidable due to VS Code processing the document before any extensions.
+* The censoring may flicker when changing between opened files in the editor
 * At the moment, there is no option to add custom regular expressions.
 * `.*` will be automatically transformed to `[^\s]*` to enable multiple censors in a single line. This means: keys with spaces might behave differently than expected.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,11 +18,11 @@ import {
 import CensoringCodeLensProvider from "./providers/CensoringCodeLensProvider";
 import CensoringProvider from "./providers/CensoringProvider";
 import ConfigurationProvider, { Configuration } from "./providers/ConfigurationProvider";
+import { dirname } from "path";
 
 let configurationProvider = new ConfigurationProvider();
 let censoringCodeLensProvider: CensoringCodeLensProvider;
-let instanceMap = new Map<TextDocument, CensoringProvider>();
-let watchers = new Map<string, FileSystemWatcher>();
+let instanceMap = new Map<string, CensoringProvider>();
 
 export async function activate(context: ExtensionContext) {
   await ConfigurationProvider.init();
@@ -48,55 +48,47 @@ export async function activate(context: ExtensionContext) {
       env.clipboard.writeText(text);
       window.showInformationMessage("Censored field copied to clipboard!");
     }),
-    commands.registerTextEditorCommand("censitive.displayCensoredRange", (editor, _, range?: Range) => {
+    commands.registerTextEditorCommand("censitive.displayCensoredRange", async (editor, _, range?: Range) => {
       if (!range) {
         return window.showErrorMessage("No censored field found. This command should not be triggered manually.");
       }
 
-      findOrCreateInstance(editor.document).then((censoring) => {
-        censoring.addVisibleRange(range);
+      const censoring = await findOrCreateInstance(editor.document);
+
+      censoring.addVisibleRange(range);
+      censoring.applyCensoredRanges();
+      setTimeout(() => {
+        censoring.removeVisibleRange(range);
         censoring.applyCensoredRanges();
-        setTimeout(() => {
-          censoring.removeVisibleRange(range);
-          censoring.applyCensoredRanges();
-        }, config.showTimeoutSeconds * 1000);
-      });
-    })
+      }, config.showTimeoutSeconds * 1000);
+    }),
+    createConfigWatcher()
   );
+
+  if (userHome) {
+    context.subscriptions.push(createConfigWatcher(Uri.file(userHome)));
+  }
 
   window.onDidChangeVisibleTextEditors(onVisibleEditorsChanged, null, context.subscriptions);
   workspace.onDidCloseTextDocument(onCloseDocument, null, context.subscriptions);
   workspace.onDidChangeConfiguration(onConfigurationChange, null, context.subscriptions);
   extensions.onDidChange(onConfigurationChange, null, context.subscriptions);
-  workspace.onDidChangeWorkspaceFolders(({ added, removed }) => {
-    added.forEach(({ name, uri }) => watchWorkspace(name, uri));
-    removed.forEach(({ name }) => {
-      watchers.get(name)?.dispose();
-      watchers.delete(name);
-    });
-  });
-
-  workspace.workspaceFolders?.forEach(({ name, uri }) => watchWorkspace(name, uri));
-  if (userHome) {
-    watchWorkspace(ConfigurationProvider.globalWorkspaceName, Uri.file(userHome));
-  }
 }
 
 export function deactivate() {
   instanceMap.forEach((instance) => instance.dispose());
-  watchers.forEach((watcher) => watcher.dispose());
-
   instanceMap.clear();
-  watchers.clear();
 }
 
-function watchWorkspace(name: string, folder: Uri) {
-  const configWatcher = workspace.createFileSystemWatcher(new RelativePattern(folder, "**/.censitive"));
-  configWatcher.onDidCreate(onCensorConfigChanged.bind(null, folder));
-  configWatcher.onDidChange(onCensorConfigChanged.bind(null, folder));
-  configWatcher.onDidDelete(() => onCensorConfigChanged(folder, null));
+function createConfigWatcher(folder?: Uri) {
+  const configWatcher = workspace.createFileSystemWatcher(
+    folder ? new RelativePattern(folder, ".censitive") : "**/.censitive"
+  );
+  configWatcher.onDidCreate(onCensorConfigChanged);
+  configWatcher.onDidChange(onCensorConfigChanged);
+  configWatcher.onDidDelete(onCensorConfigChanged);
 
-  watchers.set(name, configWatcher);
+  return configWatcher;
 }
 
 async function isValidDocument(config: Configuration, document: TextDocument): Promise<boolean> {
@@ -104,22 +96,23 @@ async function isValidDocument(config: Configuration, document: TextDocument): P
 }
 
 async function findOrCreateInstance(document: TextDocument) {
-  const found = instanceMap.get(document);
+  const found = instanceMap.get(document.uri.toString());
 
   if (!found) {
     const instance = new CensoringProvider(document, configurationProvider.censorOptions, censoringCodeLensProvider);
-    instanceMap.set(document, instance);
+    instanceMap.set(document.uri.toString(), instance);
   }
 
-  return found || instanceMap.get(document)!;
+  return found || instanceMap.get(document.uri.toString())!;
 }
 
 async function doCensoring(documents: TextDocument[] = [], configChanged = false) {
   if (documents.length) {
     await Promise.all(
-      documents.map((document) =>
-        findOrCreateInstance(document).then((instance) => instance.censor(true, configChanged))
-      )
+      documents.map(async (document) => {
+        const instance = await findOrCreateInstance(document);
+        instance.censor(true, configChanged);
+      })
     );
   }
 }
@@ -129,14 +122,21 @@ async function onConfigurationChange() {
   onVisibleEditorsChanged(window.visibleTextEditors);
 }
 
-async function onCensorConfigChanged(folder: WorkspaceFolder | Uri, uri: Uri | null) {
-  await ConfigurationProvider.updateCensoringKeys(folder, uri);
+async function onCensorConfigChanged(uri: Uri) {
+  const workspaceFolder = workspace.getWorkspaceFolder(uri) ?? null;
+  const parentFolder = Uri.file(dirname(uri.fsPath));
+
+  await ConfigurationProvider.updateCensoringKeys(
+    workspaceFolder,
+    uri,
+    parentFolder.toString() === workspaceFolder?.uri.toString() ? workspaceFolder : parentFolder
+  );
   onVisibleEditorsChanged(window.visibleTextEditors, true);
 }
 
 function onCloseDocument(document: TextDocument) {
   // Dispose instance if document is closed
-  instanceMap.delete(document);
+  instanceMap.delete(document.uri.toString());
 }
 
 async function onVisibleEditorsChanged(visibleEditors: readonly TextEditor[], configChanged = false) {
@@ -145,13 +145,15 @@ async function onVisibleEditorsChanged(visibleEditors: readonly TextEditor[], co
 
   // Only update visible TextEditors with valid configuration
   const validDocuments = (
-    await Promise.all(visibleDocuments.map(async (doc) => ((await isValidDocument(config, doc)) ? doc : null)))
+    await Promise.all(
+      visibleDocuments.map(async (document) => ((await isValidDocument(config, document)) ? document : false))
+    )
   ).filter(Boolean) as TextDocument[];
   await doCensoring(validDocuments, configChanged);
 
   if (configChanged) {
     for (const [document, instance] of instanceMap) {
-      if (!(await isValidDocument(config, document))) {
+      if (!(await isValidDocument(config, instance.document))) {
         instance.dispose();
         instanceMap.delete(document);
       }

--- a/src/providers/CensoringCodeLensProvider.ts
+++ b/src/providers/CensoringCodeLensProvider.ts
@@ -38,7 +38,7 @@ export default class CensoringCodeLensProvider implements CodeLensProvider {
     const lenses: CodeLens[] = censored.map((range) => {
       const index = (lineIndex[range.start.line] = (lineIndex[range.start.line] || 0) + 1);
       return new CodeLens(range, {
-        title: index > 1 ? `Copy #${index} to Clipboard` : "Copy to Clipboard",
+        title: index > 1 ? `$(copy) Copy #${index} to Clipboard` : "$(copy) Copy to Clipboard",
         command: "censitive.copyCensoredRange",
         arguments: [range],
       });
@@ -49,7 +49,7 @@ export default class CensoringCodeLensProvider implements CodeLensProvider {
       const index = (lineIndex[range.start.line] = (lineIndex[range.start.line] || 0) + 1);
       lenses.push(
         new CodeLens(range, {
-          title: index > 1 ? `Show Censored Text #${index}` : "Show Censored Text",
+          title: index > 1 ? `$(unlock) Show Censored Text #${index}` : "$(unlock) Show Censored Text",
           command: "censitive.displayCensoredRange",
           arguments: [range],
         })

--- a/src/providers/CensoringProvider.ts
+++ b/src/providers/CensoringProvider.ts
@@ -143,7 +143,9 @@ export default class CensoringProvider {
     }
 
     const { uri, lineCount } = this.document;
-    const visibleEditors = window.visibleTextEditors.filter(({ document }) => document.uri === uri);
+    const visibleEditors = window.visibleTextEditors.filter(
+      ({ document }) => document.uri.toString() === uri.toString()
+    );
     const visibleRanges = visibleEditors.reduce<Range[]>((ranges, editor) => [...ranges, ...editor.visibleRanges], []);
 
     if (fast && lineCount > config.useFastModeMinLines) {
@@ -267,7 +269,7 @@ export default class CensoringProvider {
 
   private applyDecoration(decoration: TextEditorDecorationType, ranges: Range[]) {
     window.visibleTextEditors
-      .filter(({ document }) => document.uri === this.document.uri)
+      .filter(({ document }) => document.uri.toString() === this.document.uri.toString())
       .forEach((editor) => editor.setDecorations(decoration, ranges));
   }
 

--- a/src/providers/CensoringProvider.ts
+++ b/src/providers/CensoringProvider.ts
@@ -127,11 +127,15 @@ export default class CensoringProvider {
     const { config } = this.configurationProvider;
 
     // We need to reapply the decorations when the visibility changes
-    if (this.document.version === this.documentVersion && !configChanged) {
+    if (
+      this.document.version === this.documentVersion &&
+      this.configurationProvider.isDocumentInWorkspace(this.document) &&
+      !configChanged
+    ) {
       return this.applyCensoredRanges();
     }
 
-    const keys = this.configurationProvider.getCensoredKeys(this.document);
+    const keys = await this.configurationProvider.getCensoredKeys(this.document);
     if (keys.includes("*")) {
       this.censoredRanges = [this.document.validateRange(new Range(0, 0, this.document.lineCount, Infinity))];
       this.documentVersion = this.document.version;
@@ -207,7 +211,7 @@ export default class CensoringProvider {
       return;
     }
 
-    const keys = this.configurationProvider.getCensoredKeys(document);
+    const keys = await this.configurationProvider.getCensoredKeys(document);
     if (keys.includes("*")) {
       this.documentVersion = version;
       return this.censor(false, contentChanges === true);
@@ -269,9 +273,9 @@ export default class CensoringProvider {
 
   private async getCensoredRanges(text: string, offset?: Position): Promise<Range[]> {
     const { languageId } = this.document;
-    const keys = this.configurationProvider
-      .getCensoredKeys(this.document)
-      .filter((key) => typeof key === "string") as string[];
+    const keys = (await this.configurationProvider.getCensoredKeys(this.document)).filter(
+      (key) => typeof key === "string"
+    ) as string[];
     if (!keys.length) {
       return [];
     }
@@ -301,7 +305,7 @@ export default class CensoringProvider {
 
   public async getMultilineRanges() {
     const { languageId } = this.document;
-    const censoring = this.configurationProvider.getCensoredKeys(this.document);
+    const censoring = await this.configurationProvider.getCensoredKeys(this.document);
     const keys = censoring.filter((key) => typeof key === "string") as string[];
     const fencePatterns = censoring.filter((key) => typeof key !== "string") as FencingPattern[];
 

--- a/src/providers/ConfigurationProvider.ts
+++ b/src/providers/ConfigurationProvider.ts
@@ -1,5 +1,3 @@
-import { readFile } from "fs";
-import { promisify } from "util";
 import {
   DocumentSelector,
   env,
@@ -14,6 +12,7 @@ import {
   WorkspaceFolder,
 } from "vscode";
 import { CensorOptions } from "../decorations/CensorBar";
+import { dirname, relative, isAbsolute } from "path";
 
 export type DefaultCensoringConfig =
   | {
@@ -130,9 +129,9 @@ function isCensoringKeyIgnore(key: CensoringKeys): key is CensoringKeysIgnore {
 
 export default class ConfigurationProvider {
   public static censorKeys: { [workspace: string]: CensoringKeys[] } = {};
+  public static globalWorkspaceName = "global";
+  public static defaultWorkspaceName = "default";
   private static _config: WorkspaceConfiguration;
-  private static _globalWorkspaceName = "global";
-  private static _defaultWorkspaceName = "default";
   private static _userHome = env.appRoot;
 
   public static async init() {
@@ -145,12 +144,12 @@ export default class ConfigurationProvider {
       }
     }
     await this.updateConfig();
-    await this.loadCensoringConfigFile();
+    await this.loadCensoringConfigFiles();
   }
 
   public static async updateConfig() {
     ConfigurationProvider._config = workspace.getConfiguration("censitive");
-    ConfigurationProvider.censorKeys[ConfigurationProvider._defaultWorkspaceName] = (
+    ConfigurationProvider.censorKeys[ConfigurationProvider.defaultWorkspaceName] = (
       ((ConfigurationProvider._config as unknown) || defaults) as Configuration
     ).defaultCensoring?.map(({ exclude, ...options }) => {
       return "match" in options
@@ -164,14 +163,18 @@ export default class ConfigurationProvider {
     });
   }
 
-  public static async updateCensoringKeys(workspace: WorkspaceFolder | Uri, configFile?: Uri | null) {
-    const name = isWorkspaceFolder(workspace) ? workspace.name : ConfigurationProvider._globalWorkspaceName;
+  public static async updateCensoringKeys(
+    workspaceFolder: WorkspaceFolder | Uri | null,
+    configFile: Uri | null,
+    base: Uri | WorkspaceFolder | null = workspaceFolder
+  ) {
+    const name = base ? (isWorkspaceFolder(base) ? base.name : base.path) : ConfigurationProvider.globalWorkspaceName;
     if (!configFile) {
       return (ConfigurationProvider.censorKeys[name] = []);
     }
 
     try {
-      const content = await promisify(readFile)(configFile.fsPath);
+      const content = await workspace.fs.readFile(configFile);
       return (ConfigurationProvider.censorKeys[name] = content
         .toString()
         .split(/\r?\n/g)
@@ -181,14 +184,14 @@ export default class ConfigurationProvider {
           const [pattern, excludePattern] = patternRaw.replace(/\\:/g, ":").split(/(?<!\\)!/);
 
           const selector = pattern
-            ? isWorkspaceFolder(workspace)
-              ? { pattern: new RelativePattern(workspace, pattern.replace(/\\!/g, "!")) }
+            ? base
+              ? { pattern: new RelativePattern(base, pattern.replace(/\\!/g, "!")) }
               : pattern.replace(/\\!/g, "!")
             : null;
           const exclude =
             excludePattern &&
-            (isWorkspaceFolder(workspace)
-              ? { pattern: new RelativePattern(workspace, excludePattern.replace(/\\!/g, "!")) }
+            (base
+              ? { pattern: new RelativePattern(base, excludePattern.replace(/\\!/g, "!")) }
               : excludePattern.replace(/\\!/g, "!"));
           const keys = keyList
             .replace(/\\:/g, ":")
@@ -213,22 +216,73 @@ export default class ConfigurationProvider {
     }
   }
 
-  private static async loadCensoringConfigFile() {
+  private static async loadCensoringConfigFiles(path?: Uri) {
     const { stat } = workspace.fs;
     const workspaces = workspace.workspaceFolders || [];
-    for (const folder of workspaces) {
-      const [configFile] = await workspace.findFiles(new RelativePattern(folder, ".censitive"), null, 1);
-      await ConfigurationProvider.updateCensoringKeys(folder, configFile);
+    const insideWorkspace =
+      path &&
+      workspaces.some(({ uri }) => {
+        const relativePath = relative(uri.fsPath, path.fsPath);
+        return relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath);
+      });
+
+    if (path && insideWorkspace) {
+      // Workspace files are watched and updated on change
+      return;
+    } else if (path) {
+      // We must reload the configuration for non-workspace directories
+      // They are unwatched and opened on demand, caching would be inefficient
+      const parentDirectories = ConfigurationProvider.getParentDirectories(path);
+
+      await Promise.all(
+        parentDirectories.map(async (directory) => {
+          const censitiveFile = Uri.joinPath(directory, ".censitive");
+          const { size } = await new Promise<FileStat>((resolve, reject) =>
+            stat(censitiveFile).then(resolve, reject)
+          ).catch(() => ({ size: 0 }));
+
+          if (size > 0) {
+            await ConfigurationProvider.updateCensoringKeys(null, censitiveFile, directory);
+          }
+        })
+      );
+      return;
     }
+
+    for (const folder of workspaces) {
+      const configFiles = await workspace.findFiles(new RelativePattern(folder, "**/.censitive"));
+      await Promise.all(
+        configFiles.map((censitiveUri) => {
+          const base = censitiveUri.with({ path: censitiveUri.path.replace(/\/\.censitive$/, "") });
+          return ConfigurationProvider.updateCensoringKeys(folder, censitiveUri, base);
+        })
+      );
+    }
+
     if (ConfigurationProvider._userHome) {
       const globalConfigFile = Uri.joinPath(Uri.file(ConfigurationProvider._userHome), ".censitive");
       const { size } = await new Promise<FileStat>((resolve, reject) =>
         stat(globalConfigFile).then(resolve, reject)
       ).catch(() => ({ size: 0 }));
       if (size > 0) {
-        await ConfigurationProvider.updateCensoringKeys(globalConfigFile, globalConfigFile);
+        await ConfigurationProvider.updateCensoringKeys(null, globalConfigFile);
       }
     }
+  }
+
+  private static getParentDirectories(path: string | Uri, ignoreHome = false) {
+    const parentDirectories = [];
+    const userHomePath = Uri.file(ConfigurationProvider._userHome).fsPath;
+
+    let currentDirectory = typeof path === "string" ? path : path.fsPath;
+    while (currentDirectory !== dirname(currentDirectory)) {
+      if (!ignoreHome || currentDirectory !== userHomePath) {
+        parentDirectories.push(Uri.file(currentDirectory));
+      }
+      currentDirectory = dirname(currentDirectory);
+    }
+
+    return parentDirectories;
   }
 
   public get userHome(): string {
@@ -236,11 +290,11 @@ export default class ConfigurationProvider {
   }
 
   public get globalCensorKeys(): CensoringKeys[] {
-    return ConfigurationProvider.censorKeys[ConfigurationProvider._globalWorkspaceName] ?? [];
+    return ConfigurationProvider.censorKeys[ConfigurationProvider.globalWorkspaceName] ?? [];
   }
 
   public get defaultCensorKeys(): CensoringKeys[] {
-    return ConfigurationProvider.censorKeys[ConfigurationProvider._defaultWorkspaceName] ?? [];
+    return ConfigurationProvider.censorKeys[ConfigurationProvider.defaultWorkspaceName] ?? [];
   }
 
   public get hasGlobalCensorKeys(): boolean {
@@ -279,9 +333,10 @@ export default class ConfigurationProvider {
     );
   }
 
-  public isDocumentInCensorConfig(document: TextDocument): boolean {
-    const folder = workspace.getWorkspaceFolder(document.uri);
-    const allCensorKeys = this.getCensoringKeysForFolder(folder);
+  public async isDocumentInCensorConfig(document: TextDocument): Promise<boolean> {
+    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+    const parentFolder = Uri.file(dirname(document.uri.fsPath));
+    const allCensorKeys = await this.getCensoringKeysForFolder(workspaceFolder, parentFolder);
     const censorKeys = allCensorKeys.filter<CensoringKeysWithSelector>(isCensoringKeyWithSelector);
     const ignoreKeys = allCensorKeys.filter<CensoringKeysIgnore>(isCensoringKeyIgnore);
 
@@ -306,9 +361,15 @@ export default class ConfigurationProvider {
     return false;
   }
 
-  public getCensoredKeys(document: TextDocument): (string | FencingPattern)[] {
-    const folder = workspace.getWorkspaceFolder(document.uri);
-    const censorKeys = this.getCensoringKeysForFolder(folder);
+  public isDocumentInWorkspace(document: TextDocument): boolean {
+    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+    return !!workspaceFolder;
+  }
+
+  public async getCensoredKeys(document: TextDocument): Promise<(string | FencingPattern)[]> {
+    const workspaceFolder = workspace.getWorkspaceFolder(document.uri);
+    const parentFolder = Uri.file(dirname(document.uri.fsPath));
+    const censorKeys = await this.getCensoringKeysForFolder(workspaceFolder, parentFolder);
 
     if (censorKeys.length === 0) {
       return [];
@@ -319,24 +380,36 @@ export default class ConfigurationProvider {
     }, []);
   }
 
-  private getCensoringKeysForFolder(folder?: WorkspaceFolder): CensoringKeys[] {
+  private async getCensoringKeysForFolder(base?: WorkspaceFolder, subPath?: Uri): Promise<CensoringKeys[]> {
     const { mergeGlobalCensoring, mergeDefaultCensoring } = this.config;
-    const hasGlobalCensoring = this.hasGlobalCensorKeys;
-    const hasLocalCensoring = folder && ConfigurationProvider.censorKeys[folder.name];
 
-    const censorKeyGroups = [
-      mergeGlobalCensoring || !hasLocalCensoring ? this.globalCensorKeys : [],
-      mergeDefaultCensoring || (!hasLocalCensoring && !hasGlobalCensoring) ? this.defaultCensorKeys : [],
-    ];
-    const censorKeys = this.mergeCensoringKeys(
-      (folder && ConfigurationProvider.censorKeys[folder.name]) ?? [],
-      ...censorKeyGroups
-    );
+    const baseCensoringKeys = base ? ConfigurationProvider.censorKeys[base.name] : undefined;
+    const censorKeyGroups = [];
+
+    if (subPath && !base) {
+      // Load config for files outside the workspace
+      const parentDirectories = ConfigurationProvider.getParentDirectories(subPath);
+      await ConfigurationProvider.loadCensoringConfigFiles(subPath);
+
+      for (const directory of parentDirectories) {
+        if (ConfigurationProvider.censorKeys[directory.path]) {
+          censorKeyGroups.push(ConfigurationProvider.censorKeys[directory.path]);
+        }
+      }
+    }
+
+    if ((mergeGlobalCensoring || !baseCensoringKeys) && this.hasGlobalCensorKeys) {
+      censorKeyGroups.push(this.globalCensorKeys);
+    } else if (mergeDefaultCensoring || !baseCensoringKeys) {
+      censorKeyGroups.push(this.defaultCensorKeys);
+    }
+
+    const censorKeys = this.mergeCensoringKeys(baseCensoringKeys ?? [], ...censorKeyGroups);
 
     return censorKeys.map((censorKey) => {
       let { selector, exclude } = censorKey;
-      selector = selector && this.extendGlobSelector(selector, folder);
-      exclude = exclude && this.extendGlobSelector(exclude, folder);
+      selector = selector && this.extendGlobSelector(selector, base);
+      exclude = exclude && this.extendGlobSelector(exclude, base);
 
       return { ...censorKey, selector, exclude } as CensoringKeys;
     });


### PR DESCRIPTION
This release fixes a few longstanding bugs and adds Support for `.censitive` files in subdirectories.

### Features

- Support `.censitive` files in any directory

### Fixes

- Fix some cache-misses for already censored files
- Always keep track of censoring changes across all active workspaces and the hme directory
- Decrease the scope of file watchers
- Speed up invalidation on censoring change