### PR TITLE
fix: support censoring for `#define` in cpp / c

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,9 @@
         "censitive.assignmentRegex": {
           "default": {
             "default": "[\\t ]*[:=][=>]?[\\t ]*",
-            "yaml": "[\\t ]*:[\\t ]*(?!>|\\|)"
+            "yaml": "[\\t ]*:[\\t ]*(?!>|\\|)",
+            "cpp": "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)",
+            "c": "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)"
           },
           "description": "Regex used to detect assignments",
           "type": "object",

--- a/src/providers/ConfigurationProvider.ts
+++ b/src/providers/ConfigurationProvider.ts
@@ -95,6 +95,8 @@ export const defaults: Configuration = {
   assignmentRegex: {
     default: "[\\t ]*[:=][=>]?[\\t ]*",
     yaml: "[\\t ]*:[\\t ]*(?!>|\\|)",
+    cpp: "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)",
+    c: "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)",
   },
   censoring: {
     color: "theme.editorInfo.background",


### PR DESCRIPTION
Will add support for `#define` syntax in cpp / c. If `censitive.assignmentRegex` option was overridden, the new default configuration must be merged:

```json
{
    "censitive.assignmentRegex": {
          "default": "[\\t ]*[:=][=>]?[\\t ]*",
          "yaml": "[\\t ]*:[\\t ]*(?!>|\\|)",
          "cpp": "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)",
          "c": "(?:[\\t ]*=[\\t ]*|(?<=^#define[\\t ]+.+)[\\t ]+)"
      },
}
```